### PR TITLE
Use recent pystan version (3.4.0)

### DIFF
--- a/baycomp/hierarchical-t-test.stan
+++ b/baycomp/hierarchical-t-test.stan
@@ -49,22 +49,22 @@
     real detM;
 
     //The determinant of M is analytically known
-    detM <- (1+(Nsamples-1)*rho)*(1-rho)^(Nsamples-1);
+    detM = (1+(Nsamples-1)*rho)*(1-rho)^(Nsamples-1);
 
     //build H and invM. They do not depend on the data.
     for (j in 1:Nsamples){
-      zeroMeanVec[j]<-0;
-      H[j]<-1;
+      zeroMeanVec[j] = 0;
+      H[j] = 1;
       for (i in 1:Nsamples){
         if (j==i)
-          invM[j,i]<- (1 + (Nsamples-2)*rho)*pow((1-rho),Nsamples-2);
+          invM[j,i] = (1 + (Nsamples-2)*rho)*pow((1-rho),Nsamples-2);
         else
-          invM[j,i]<- -rho * pow((1-rho),Nsamples-2);
+          invM[j,i] = -rho * pow((1-rho),Nsamples-2);
         }
     }
     /*at this point invM contains the adjugate of M.
     we  divide it by det(M) to obtain the inverse of M.*/
-    invM <-invM/detM;
+    invM = invM/detM;
   }
 
   parameters {
@@ -109,21 +109,21 @@
     vector[q] logLik;
 
     //degrees of freedom
-    nu <- nuMinusOne + 1 ;
+    nu = nuMinusOne + 1 ;
 
     //1 over the variance of each data set
-    oneOverSigma2 <- rep_vector(1, q) ./ sigma;
-    oneOverSigma2 <- oneOverSigma2 ./ sigma;
+    oneOverSigma2 = rep_vector(1, q) ./ sigma;
+    oneOverSigma2 = oneOverSigma2 ./ sigma;
 
     /*the data (x) minus a matrix done as follows:
     the delta vector (of lenght q) pasted side by side Nsamples times*/
-    diff <- x - rep_matrix(delta,Nsamples);
+    diff = x - rep_matrix(delta,Nsamples);
 
     //efficient matrix computation of the likelihood.
-    diagQuad <- diagonal (quad_form (invM,diff'));
-    logDetSigma <- 2*Nsamples*log(sigma) + log(detM) ;
-    logLik <- -0.5 * logDetSigma - 0.5*Nsamples*log(6.283);
-    logLik <- logLik - 0.5 * oneOverSigma2 .* diagQuad;
+    diagQuad = diagonal (quad_form (invM,diff'));
+    logDetSigma = 2*Nsamples*log(sigma) + log(detM) ;
+    logLik = -0.5 * logDetSigma - 0.5*Nsamples*log(6.283);
+    logLik = logLik - 0.5 * oneOverSigma2 .* diagQuad;
 
   }
 
@@ -139,5 +139,5 @@
     delta ~ student_t(nu, delta0, std0);
 
     //logLik is computed in the previous block
-    increment_log_prob(sum(logLik));
+    target += sum(logLik);
   }

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,9 @@ setup(
         'matplotlib >= 2.1.2',
         'numpy >= 1.13.1',
         'scipy >= 0.19.1'],
+    extra_requires=[
+        'pystan >= 3.4.0'
+    ],
     python_requires='>=3',
     package_data={
         'baycomp': ['hierarchical-t-test.stan']}


### PR DESCRIPTION
## Reasons for this change:


The PyStan version this package used before (2.19.1.1) is almost three years old now. Other projects require a more recent version (typically > 3.0.0) which leads to incompatibilities if baycomp is meant to be used in those projects. Aside from that, PyStan 3.0.0 was a complete rewrite with a much cleaner user experience (e.g. model caching by default). A summary of changes from PyStan 2.19.1.1 to 3.0.0 can be found [here](https://PyStan.readthedocs.io/en/latest/upgrading.html).


## Summary of changes/implications for baycomp:


- Fix deprecation warnings in Stan model code:
  - `<-` was replaced by `=`
  - `increment_log_prob` was replaced by `target +=`
- Use the new PyStan interface in place of the old one.
- Pickling Stan models manually is not necessary any more: Since version 3, PyStan only interacts with httpstan which already performs model caching.
- Windows support might become worse than before (PyStan >= 3.0.0 does not officially support Windows any more whereas PyStan < 3.0.0 had “partial support” according to [the PyStan docs](https://PyStan.readthedocs.io/en/latest/upgrading.html)—whatever that may mean).


Note that I deliberately did not perform any other changes (e.g. regarding code formatting etc.) so that the changeset can be checked straightforwardly.
